### PR TITLE
Upgrade Log4j dependency to 2.14.1

### DIFF
--- a/quaerite-analysis/pom.xml
+++ b/quaerite-analysis/pom.xml
@@ -68,9 +68,9 @@
             <version>${commons.cli.version}</version>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.14.1</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/quaerite-analysis/src/main/java/org/tallison/quaerite/analysis/CompareAnalyzers.java
+++ b/quaerite-analysis/src/main/java/org/tallison/quaerite/analysis/CompareAnalyzers.java
@@ -51,7 +51,8 @@ import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.io.input.BOMInputStream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableLong;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.tallison.quaerite.connectors.SearchClient;
 import org.tallison.quaerite.connectors.SearchClientException;
 import org.tallison.quaerite.connectors.SearchClientFactory;
@@ -63,7 +64,7 @@ import org.tallison.quaerite.core.util.MapUtil;
 public class CompareAnalyzers {
 
     static Options OPTIONS = new Options();
-    static Logger LOG = Logger.getLogger(SearchClient.class);
+    static Logger LOG = LogManager.getLogger(SearchClient.class);
     private static int DEFAULT_NUM_THREADS = 10;
     private static int DEFAULT_MIN_SET_SIZE = 1;
     private static int DEFAULT_MIN_DF = 1;

--- a/quaerite-cli/pom.xml
+++ b/quaerite-cli/pom.xml
@@ -77,9 +77,9 @@
             <version>${commons.cli.version}</version>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.14.1</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/quaerite-cli/src/main/java/org/tallison/quaerite/cli/AbstractCLI.java
+++ b/quaerite-cli/src/main/java/org/tallison/quaerite/cli/AbstractCLI.java
@@ -24,7 +24,8 @@ import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.tallison.quaerite.core.Experiment;
 import org.tallison.quaerite.core.ExperimentSet;
 import org.tallison.quaerite.core.scorers.Scorer;
@@ -32,7 +33,7 @@ import org.tallison.quaerite.db.ExperimentDB;
 
 public abstract class AbstractCLI {
 
-    static Logger LOG = Logger.getLogger(AbstractCLI.class);
+    static Logger LOG = LogManager.getLogger(AbstractCLI.class);
 
     static ExperimentSet addExperiments(ExperimentDB experimentDB,
                                         Path experimentsJson, boolean merge,

--- a/quaerite-cli/src/main/java/org/tallison/quaerite/cli/AbstractExperimentRunner.java
+++ b/quaerite-cli/src/main/java/org/tallison/quaerite/cli/AbstractExperimentRunner.java
@@ -44,7 +44,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.math3.stat.inference.TTest;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.tallison.quaerite.connectors.QueryRequest;
 import org.tallison.quaerite.connectors.SearchClient;
 import org.tallison.quaerite.connectors.SearchClientException;
@@ -74,7 +75,7 @@ public abstract class AbstractExperimentRunner extends AbstractCLI {
     static final Judgments POISON = new Judgments(new QueryInfo("",
             "", new QueryStrings(), -1));
 
-    static Logger LOG = Logger.getLogger(AbstractExperimentRunner.class);
+    static Logger LOG = LogManager.getLogger(AbstractExperimentRunner.class);
 
     //number of retries allowed for querying the search application
     static final int MAX_RETRIES = 2;

--- a/quaerite-cli/src/main/java/org/tallison/quaerite/cli/CopyIndex.java
+++ b/quaerite-cli/src/main/java/org/tallison/quaerite/cli/CopyIndex.java
@@ -40,7 +40,8 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.tallison.quaerite.connectors.SearchClient;
 import org.tallison.quaerite.connectors.SearchClientException;
 import org.tallison.quaerite.connectors.SearchClientFactory;
@@ -50,7 +51,7 @@ import org.tallison.quaerite.core.queries.Query;
 
 public class CopyIndex extends AbstractCLI {
 
-    static Logger LOG = Logger.getLogger(CopyIndex.class);
+    static Logger LOG = LogManager.getLogger(CopyIndex.class);
 
     private static final int NUM_THREADS = 10;
     private static final int BATCH_SIZE = 100;

--- a/quaerite-cli/src/main/java/org/tallison/quaerite/cli/QueryLoader.java
+++ b/quaerite-cli/src/main/java/org/tallison/quaerite/cli/QueryLoader.java
@@ -36,7 +36,8 @@ import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.io.input.BOMInputStream;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.tallison.quaerite.core.Judgments;
 import org.tallison.quaerite.core.QueryInfo;
 import org.tallison.quaerite.core.QueryStrings;
@@ -50,7 +51,7 @@ class QueryLoader {
     private static final String RELEVANCE = "rating";
     private static final String COUNT = "count";
 
-    static Logger LOG = Logger.getLogger(AbstractCLI.class);
+    static Logger LOG = LogManager.getLogger(AbstractCLI.class);
 
     private static Set<String> DEFINED_JUDGMENT_COLUMNS =
             Collections.unmodifiableSet(

--- a/quaerite-cli/src/main/java/org/tallison/quaerite/cli/RunExperiments.java
+++ b/quaerite-cli/src/main/java/org/tallison/quaerite/cli/RunExperiments.java
@@ -31,7 +31,8 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.tallison.quaerite.connectors.SearchClientException;
 import org.tallison.quaerite.core.Experiment;
 import org.tallison.quaerite.core.ExperimentConfig;
@@ -42,7 +43,7 @@ public class RunExperiments extends AbstractExperimentRunner {
 
     public static String DEFAULT_ID_FIELD = "id";
 
-    static Logger LOG = Logger.getLogger(RunExperiments.class);
+    static Logger LOG = LogManager.getLogger(RunExperiments.class);
 
     static Options OPTIONS = new Options();
 

--- a/quaerite-cli/src/main/java/org/tallison/quaerite/cli/RunGA.java
+++ b/quaerite-cli/src/main/java/org/tallison/quaerite/cli/RunGA.java
@@ -37,7 +37,8 @@ import org.apache.commons.cli.ParseException;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 import org.apache.commons.math3.stat.descriptive.rank.Median;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.tallison.quaerite.connectors.SearchClientException;
 import org.tallison.quaerite.core.Experiment;
 import org.tallison.quaerite.core.ExperimentFactory;
@@ -57,7 +58,7 @@ import org.tallison.quaerite.db.TrainTestJudmentListPair;
 
 public class RunGA extends AbstractExperimentRunner {
 
-    static Logger LOG = Logger.getLogger(RunGA.class);
+    static Logger LOG = LogManager.getLogger(RunGA.class);
 
     static Options OPTIONS = new Options();
 

--- a/quaerite-cli/src/main/java/org/tallison/quaerite/db/ExperimentDB.java
+++ b/quaerite-cli/src/main/java/org/tallison/quaerite/db/ExperimentDB.java
@@ -40,7 +40,8 @@ import java.util.Set;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.tallison.quaerite.core.Experiment;
 import org.tallison.quaerite.core.ExperimentConfig;
 import org.tallison.quaerite.core.ExperimentSet;
@@ -60,7 +61,7 @@ public class ExperimentDB implements Closeable {
 
     private static Gson GSON = new GsonBuilder().create();
 
-    static Logger LOG = Logger.getLogger(ExperimentDB.class);
+    static Logger LOG = LogManager.getLogger(ExperimentDB.class);
     final Connection connection;
     private final PreparedStatement selectExperiments;
     private final PreparedStatement selectOneExperiment;

--- a/quaerite-cli/src/main/java/org/tallison/quaerite/db/QueryRunnerDBClient.java
+++ b/quaerite-cli/src/main/java/org/tallison/quaerite/db/QueryRunnerDBClient.java
@@ -28,7 +28,8 @@ import java.util.List;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.tallison.quaerite.core.QueryInfo;
 import org.tallison.quaerite.core.SearchResultSet;
 import org.tallison.quaerite.core.StoredDocument;
@@ -42,7 +43,7 @@ import org.tallison.quaerite.core.scorers.Scorer;
 public class QueryRunnerDBClient implements Closeable {
 
     private static Gson GSON = new GsonBuilder().create();
-    static Logger LOG = Logger.getLogger(QueryRunnerDBClient.class);
+    static Logger LOG = LogManager.getLogger(QueryRunnerDBClient.class);
 
     private PreparedStatement insertScores;
     private PreparedStatement insertResults;

--- a/quaerite-connectors/src/main/java/org/tallison/quaerite/connectors/ESClient.java
+++ b/quaerite-connectors/src/main/java/org/tallison/quaerite/connectors/ESClient.java
@@ -40,7 +40,8 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.HttpClient;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.tallison.quaerite.core.FacetResult;
 import org.tallison.quaerite.core.SearchResultSet;
 import org.tallison.quaerite.core.StoredDocument;
@@ -77,7 +78,7 @@ public class ESClient extends SearchClient {
     }
 
 
-    static Logger LOG = Logger.getLogger(ESClient.class);
+    static Logger LOG = LogManager.getLogger(ESClient.class);
 
     private final String url;//must include esbase and es collection; must end in /
     private final String esBase;//must end in /

--- a/quaerite-connectors/src/main/java/org/tallison/quaerite/connectors/HttpUtils.java
+++ b/quaerite-connectors/src/main/java/org/tallison/quaerite/connectors/HttpUtils.java
@@ -53,11 +53,12 @@ import org.apache.http.protocol.HTTP;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.ssl.SSLContexts;
 import org.apache.http.util.EntityUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class HttpUtils {
 
-    static Logger LOG = Logger.getLogger(HttpUtils.class);
+    static Logger LOG = LogManager.getLogger(HttpUtils.class);
 
     public static byte[] get(HttpClient httpClient, String url) throws SearchClientException {
         //overly simplistic...need to add proxy, etc., but good enough for now

--- a/quaerite-connectors/src/main/java/org/tallison/quaerite/connectors/IdGrabber.java
+++ b/quaerite-connectors/src/main/java/org/tallison/quaerite/connectors/IdGrabber.java
@@ -23,7 +23,8 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.tallison.quaerite.core.queries.Query;
 
 /**
@@ -33,7 +34,7 @@ import org.tallison.quaerite.core.queries.Query;
  * to the queue to signal to the consumers to end.</p>
  */
 public abstract class IdGrabber implements Callable<Integer> {
-    static Logger LOG = Logger.getLogger(IdGrabber.class);
+    static Logger LOG = LogManager.getLogger(IdGrabber.class);
 
     protected final String idField;
     protected final ArrayBlockingQueue<Set<String>> ids;

--- a/quaerite-connectors/src/main/java/org/tallison/quaerite/connectors/SearchClient.java
+++ b/quaerite-connectors/src/main/java/org/tallison/quaerite/connectors/SearchClient.java
@@ -40,7 +40,8 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.util.EntityUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.tallison.quaerite.core.ExperimentConfig;
 import org.tallison.quaerite.core.FacetResult;
 import org.tallison.quaerite.core.SearchResultSet;
@@ -64,7 +65,7 @@ public abstract class SearchClient implements Closeable {
     public abstract FacetResult facet(QueryRequest query)
             throws SearchClientException, IOException;
 
-    static Logger LOG = Logger.getLogger(SearchClient.class);
+    static Logger LOG = LogManager.getLogger(SearchClient.class);
 
     private final HttpClient httpClient;
 

--- a/quaerite-connectors/src/main/java/org/tallison/quaerite/connectors/Solr4Client.java
+++ b/quaerite-connectors/src/main/java/org/tallison/quaerite/connectors/Solr4Client.java
@@ -26,7 +26,8 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import org.apache.http.client.HttpClient;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.tallison.quaerite.core.StoredDocument;
 import org.tallison.quaerite.core.queries.LuceneQuery;
 import org.tallison.quaerite.core.queries.TermsQuery;
@@ -36,7 +37,7 @@ import org.tallison.quaerite.core.queries.TermsQuery;
  */
 public class Solr4Client extends SolrClient {
 
-    static Logger LOG = Logger.getLogger(Solr4Client.class);
+    static Logger LOG = LogManager.getLogger(Solr4Client.class);
 
     private final int minorVersion;
     /**

--- a/quaerite-connectors/src/main/java/org/tallison/quaerite/connectors/SolrClient.java
+++ b/quaerite-connectors/src/main/java/org/tallison/quaerite/connectors/SolrClient.java
@@ -43,7 +43,8 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.HttpClient;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.tallison.quaerite.core.FacetResult;
 import org.tallison.quaerite.core.SearchResultSet;
 import org.tallison.quaerite.core.StoredDocument;
@@ -76,7 +77,7 @@ public class SolrClient extends SearchClient {
         SYS_INTERNAL_FIELDS = Collections.unmodifiableSet(tmp);
     }
 
-    static Logger LOG = Logger.getLogger(SolrClient.class);
+    static Logger LOG = LogManager.getLogger(SolrClient.class);
 
     static final Gson GSON = new Gson();
     private static String DEFAULT_ID_FIELD = "id";

--- a/quaerite-core/pom.xml
+++ b/quaerite-core/pom.xml
@@ -70,9 +70,9 @@
             <version>${gson.version}</version>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.14.1</version>
         </dependency>
 
         <dependency>

--- a/quaerite-core/src/main/java/org/tallison/quaerite/core/scorers/HighestRank.java
+++ b/quaerite-core/src/main/java/org/tallison/quaerite/core/scorers/HighestRank.java
@@ -18,7 +18,8 @@ package org.tallison.quaerite.core.scorers;
 
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.tallison.quaerite.core.Judgments;
 import org.tallison.quaerite.core.SearchResultSet;
 
@@ -28,7 +29,7 @@ import org.tallison.quaerite.core.SearchResultSet;
 public class HighestRank extends AbstractJudgmentScorer {
     public final static int NOT_FOUND = -1;
 
-    static Logger LOG = Logger.getLogger(HighestRank.class);
+    static Logger LOG = LogManager.getLogger(HighestRank.class);
 
     public HighestRank(int atN) {
         super("highestRank", atN);

--- a/quaerite-core/src/main/java/org/tallison/quaerite/core/scorers/HighestRankReciprocal.java
+++ b/quaerite-core/src/main/java/org/tallison/quaerite/core/scorers/HighestRankReciprocal.java
@@ -16,7 +16,8 @@
  */
 package org.tallison.quaerite.core.scorers;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.tallison.quaerite.core.Judgments;
 import org.tallison.quaerite.core.SearchResultSet;
 
@@ -25,7 +26,7 @@ import org.tallison.quaerite.core.SearchResultSet;
  */
 public class HighestRankReciprocal extends HighestRank {
 
-    static Logger LOG = Logger.getLogger(HighestRankReciprocal.class);
+    static Logger LOG = LogManager.getLogger(HighestRankReciprocal.class);
 
     public HighestRankReciprocal(int atN) {
         super("highestRankReciprocal", atN);

--- a/quaerite-core/src/main/java/org/tallison/quaerite/core/scorers/NDCG.java
+++ b/quaerite-core/src/main/java/org/tallison/quaerite/core/scorers/NDCG.java
@@ -19,7 +19,8 @@ package org.tallison.quaerite.core.scorers;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.tallison.quaerite.core.Judgments;
 import org.tallison.quaerite.core.SearchResultSet;
 import org.tallison.quaerite.core.StoredDocument;
@@ -27,7 +28,7 @@ import org.tallison.quaerite.core.StoredDocument;
 
 public class NDCG extends DiscountedCumulativeGain2002 {
 
-    static Logger LOG = Logger.getLogger(NDCG.class);
+    static Logger LOG = LogManager.getLogger(NDCG.class);
 
     public NDCG(int atN) {
         super("ndcg", atN);

--- a/quaerite-core/src/main/java/org/tallison/quaerite/core/serializers/QuerySerializer.java
+++ b/quaerite-core/src/main/java/org/tallison/quaerite/core/serializers/QuerySerializer.java
@@ -39,7 +39,8 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.tallison.quaerite.core.QueryStrings;
 import org.tallison.quaerite.core.features.BF;
 import org.tallison.quaerite.core.features.BQ;
@@ -92,7 +93,7 @@ import org.tallison.quaerite.core.util.MathUtil;
 public class QuerySerializer extends AbstractFeatureSerializer
         implements JsonSerializer<Query>, JsonDeserializer<Query> {
 
-    static Logger LOG = Logger.getLogger(QuerySerializer.class);
+    static Logger LOG = LogManager.getLogger(QuerySerializer.class);
 
     private static final Pattern PERCENT_MATCHER = Pattern.compile("(-?\\d+(\\.\\d+)?)%");
     private static final String DEFAULT_FIELD = "defaultField";

--- a/quaerite-parent/pom.xml
+++ b/quaerite-parent/pom.xml
@@ -85,9 +85,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>log4j</groupId>
-                <artifactId>log4j</artifactId>
-                <version>1.2.17</version>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>2.14.1</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/quaerite-solr-tools/src/main/java/org/tallison/quaerite/solrtools/ElevateAnalysisEvaluator.java
+++ b/quaerite-solr-tools/src/main/java/org/tallison/quaerite/solrtools/ElevateAnalysisEvaluator.java
@@ -41,7 +41,8 @@ import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.io.input.BOMInputStream;
 import org.apache.commons.lang3.mutable.MutableLong;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.tallison.quaerite.analysis.EquivalenceSet;
 import org.tallison.quaerite.connectors.SearchClient;
 import org.tallison.quaerite.connectors.SearchClientException;
@@ -50,7 +51,7 @@ import org.tallison.quaerite.core.util.MapUtil;
 import org.tallison.quaerite.core.util.StringUtil;
 
 public class ElevateAnalysisEvaluator {
-    static Logger LOG = Logger.getLogger(ElevateAnalysisEvaluator.class);
+    static Logger LOG = LogManager.getLogger(ElevateAnalysisEvaluator.class);
 
     static Options OPTIONS = new Options();
 

--- a/quaerite-solr-tools/src/main/java/org/tallison/quaerite/solrtools/ElevateElevateComparer.java
+++ b/quaerite-solr-tools/src/main/java/org/tallison/quaerite/solrtools/ElevateElevateComparer.java
@@ -36,14 +36,15 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.tallison.quaerite.connectors.SearchClient;
 import org.tallison.quaerite.connectors.SearchClientException;
 import org.tallison.quaerite.connectors.SearchClientFactory;
 import org.xml.sax.SAXException;
 
 public class ElevateElevateComparer {
-    static Logger LOG = Logger.getLogger(ElevateAnalysisEvaluator.class);
+    static Logger LOG = LogManager.getLogger(ElevateAnalysisEvaluator.class);
 
     static Options OPTIONS = new Options();
 

--- a/quaerite-solr-tools/src/main/java/org/tallison/quaerite/solrtools/ElevateQueryComparer.java
+++ b/quaerite-solr-tools/src/main/java/org/tallison/quaerite/solrtools/ElevateQueryComparer.java
@@ -52,7 +52,8 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.io.input.BOMInputStream;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.tallison.quaerite.connectors.QueryRequest;
 import org.tallison.quaerite.connectors.SearchClient;
 import org.tallison.quaerite.connectors.SearchClientFactory;
@@ -61,7 +62,7 @@ import org.tallison.quaerite.core.queries.TermQuery;
 import org.tallison.quaerite.core.util.MapUtil;
 
 public class ElevateQueryComparer {
-    static Logger LOG = Logger.getLogger(ElevateQueryComparer.class);
+    static Logger LOG = LogManager.getLogger(ElevateQueryComparer.class);
 
     static Options OPTIONS = new Options();
 

--- a/quaerite-solr-tools/src/main/java/org/tallison/quaerite/solrtools/ElevateScraper.java
+++ b/quaerite-solr-tools/src/main/java/org/tallison/quaerite/solrtools/ElevateScraper.java
@@ -33,7 +33,8 @@ import java.util.regex.Matcher;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -41,7 +42,7 @@ import org.xml.sax.helpers.DefaultHandler;
 
 public class ElevateScraper extends DefaultHandler {
 
-    static Logger LOG = Logger.getLogger(ElevateScraper.class);
+    static Logger LOG = LogManager.getLogger(ElevateScraper.class);
     private final Matcher idMatcher;
     private boolean inQuery = false;
     private String currentQuery = null;

--- a/quaerite-solr-tools/src/main/java/org/tallison/quaerite/solrtools/WinnowAnalyzedElevate.java
+++ b/quaerite-solr-tools/src/main/java/org/tallison/quaerite/solrtools/WinnowAnalyzedElevate.java
@@ -43,7 +43,8 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.tallison.quaerite.connectors.SearchClient;
 import org.tallison.quaerite.connectors.SearchClientException;
 import org.tallison.quaerite.connectors.SearchClientFactory;
@@ -54,7 +55,7 @@ import org.tallison.quaerite.core.util.StringUtil;
  * become duplicates after analysis via a given field.
  */
 public class WinnowAnalyzedElevate {
-    static Logger LOG = Logger.getLogger(WinnowAnalyzedElevate.class);
+    static Logger LOG = LogManager.getLogger(WinnowAnalyzedElevate.class);
 
     static Options OPTIONS = new Options();
 


### PR DESCRIPTION
This addresses CVEs:
https://nvd.nist.gov/vuln/detail/CVE-2020-9488
https://nvd.nist.gov/vuln/detail/CVE-2019-17571

See: https://github.com/tballison/quaerite/issues/12